### PR TITLE
Add reformation-day to the holidays of Lower Saxony

### DIFF
--- a/german-holidays.el
+++ b/german-holidays.el
@@ -113,7 +113,8 @@ INCLUDES are holidays added to the `holiday-german--national-holidays'."
   (holiday-german--state-holidays '(reformation-day))
   "Holidays for Mecklenburg West Pomerania.")
 
-(defvar holiday-german-NI-holidays holiday-german--national-holidays
+(defvar holiday-german-NI-holidays
+  (holiday-german--state-holidays '(reformation-day))
   "Holidays for Lower Saxony.")
 
 (defvar holiday-german-NW-holidays


### PR DESCRIPTION
The reformation-day was added as public holiday in Lower Saxony on the
22th June 2018. See here [1]

[1] https://www.mi.niedersachsen.de/themen/allgemeine_angelegenheiten_inneren/feiertagsrecht/feiertagsrecht-60368.html